### PR TITLE
Fixed paths to resources

### DIFF
--- a/addons/dialogue_trees/scripts/dialogue_nodes/variable/DialogueVariableNodeInstance.cs
+++ b/addons/dialogue_trees/scripts/dialogue_nodes/variable/DialogueVariableNodeInstance.cs
@@ -44,8 +44,8 @@ public partial class DialogueVariableNodeInstance : DialogueNodeInstance
 		{
 			new(
 				"Enum",
-                ResourceLoader.Load<Script>($"{DialogueTreesPlugin.DialogueTreesPluginPath}/scripts/variable_node_instances/DialogueEnumSetterInstance.cs"),
-                ResourceLoader.Load<Script>($"{DialogueTreesPlugin.DialogueTreesPluginPath}/scripts/variable_node_instances/DialogueEnumConditionInstance.cs")
+                ResourceLoader.Load<Script>($"{DialogueTreesPlugin.DialogueTreesPluginPath}/scripts/variable_subnodes/enum/DialogueEnumSetterInstance.cs"),
+                ResourceLoader.Load<Script>($"{DialogueTreesPlugin.DialogueTreesPluginPath}/scripts/variable_subnodes/enum/DialogueEnumConditionInstance.cs")
 			)
 		};
 	}


### PR DESCRIPTION
The paths to the files DialogueEnumSetterInstance.cs and DialogueEnumConditionInstance.cs have been corrected: the variable_node_instances directory was not found in the project, but the specified files were located along the variable_subnodes/enum path.
In the version before the change, when loading a tree with the Set Variable node, a number of errors occurred (check screenshot), notifying that it was impossible to load the resource along the specified path.
![image](https://github.com/Ardot66/DialogueTrees/assets/43432770/a05320f9-5064-44d2-b8fe-04f7d19b915a)
