### PR TITLE
Work around for Godot 4.3 Regression

### DIFF
--- a/addons/dialogue_trees/scripts/core/DialogueGraph.cs
+++ b/addons/dialogue_trees/scripts/core/DialogueGraph.cs
@@ -19,6 +19,7 @@ public partial class DialogueGraph : GraphEdit
 	_fromPort = "from_port",
 	_toNode = "to_node",
 	_toPort = "to_port";
+	private static readonly StringName _connectionLayer = "_connection_layer";
 
 	public EditorUndoRedoManager UndoRedo;
 	public DialogueTreesPlugin Plugin;
@@ -216,14 +217,18 @@ public partial class DialogueGraph : GraphEdit
 
 			loadedNodes.Add(node);
 		}
-			
-		for(int x = 0; x < treeData.GetConnectionsCount(); x++)
+
+		var children = GetChildren()
+			.Where(c => !c.Name.Equals(_connectionLayer))
+			.ToList();
+		var count = treeData.GetConnectionsCount();
+		for(int x = 0; x < count; x++)
 		{
 			DialogueTreeData.Connection con = treeData.GetConnection(x);
 
-			Node fromNode = GetChild(con.FromNode);
-			Node toNode = GetChild(con.ToNode);
-
+			Node fromNode = children.ElementAt(con.FromNode);
+			Node toNode = children.ElementAt(con.ToNode);
+			
 			if(fromNode is not DialogueNode || toNode is not DialogueNode)
 				continue;
 
@@ -239,7 +244,7 @@ public partial class DialogueGraph : GraphEdit
 
 			dialogueNode.GraphReady();
 			dialogueNode.Selected = true;
-		}		
+		}
 
 		_arrangingNodes = true;
 		ArrangeGraph(true);
@@ -249,13 +254,17 @@ public partial class DialogueGraph : GraphEdit
 
 	///<summary>Unloads the given DialogueTreeData and removes all loadedNodes, this is intended only for use with UndoRedo.</summary>
 	public void UnloadTree(DialogueTreeData treeData, Array<Node> loadedNodes)
-	{			
-		for(int x = 0; x < treeData.GetConnectionsCount(); x++)
+	{
+		var children = GetChildren()
+			.Where(c => !c.Name.Equals(_connectionLayer))
+			.ToList();
+		var count = treeData.GetConnectionsCount();
+		for(int x = 0; x < count; x++)
 		{
 			DialogueTreeData.Connection con = treeData.GetConnection(x);
 
-			Node fromNode = GetChild(con.FromNode);
-			Node toNode = GetChild(con.ToNode);
+			Node fromNode = children.ElementAt(con.FromNode);
+			Node toNode = children.ElementAt(con.ToNode);
 
 			if(fromNode is not DialogueNode || toNode is not DialogueNode)
 				continue;
@@ -276,6 +285,10 @@ public partial class DialogueGraph : GraphEdit
 
 		foreach(Node node in GetChildren())
 		{
+			if (node.Name.Equals(_connectionLayer))
+			{
+				continue;
+			}
 			RemoveChild(node);
 			node.QueueFree();
 		}


### PR DESCRIPTION
Godot 4.3 had seen a big change with GraphEdits and GraphNodes, and as part of that, a new node has been introduced, but since it's not marked as internal, it will also return in `GetChildren()`, resulting in the important node being deleted, and subsequently attempting to write to invalid memory space, causing Godot to crash via a SIGSEGV signal.

This will fix issue #6 by providing the following workaround:
- When evaluating children to remove in `DialogueGraph.ClearTree()`, filter out `_connection_layer`
- When reconnecting nodes after loading data from the file system, check child indices in a list excluding `_connection_layer`

This has been tested with Start/Switch/Output Dialogue nodes, but not tested further with other nodes, and regression may be introduced in certain use cases.